### PR TITLE
Connect reacts to 'error' and 'offline' events

### DIFF
--- a/src/ubimqtt.js
+++ b/src/ubimqtt.js
@@ -154,6 +154,16 @@ self.connect = function(callback)
 		{
 		handleIncomingMessage(topic, message.toString());
 		});
+
+	tempClient.on("offline", function()
+		{
+		callback(new Error("connection to the server was closed"));
+		});
+	
+	tempClient.on("error", function(error) 
+		{
+		callback(error);
+		});
 	};
 
 /**


### PR DESCRIPTION
Currently, UbiMqtt client's connect fails silently, if the connection fails or an error is encountered. 

Changes:
 - if mqtt.commit emits an 'error' -event, callback is called with the resulting error
 - if mqtt.commit emits an 'offline' -event, callback is called with a new error