### PR TITLE
Add method for disconnecting immediately from the bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Api documentation
 **Kind**: global class  
 
 * [UbiMqtt](#UbiMqtt)
-    * [new UbiMqtt(serverAddress)](#new_UbiMqtt_new)
+    * [new UbiMqtt(serverAddress, [options])](#new_UbiMqtt_new)
     * [.connect(callback)](#UbiMqtt+connect)
     * [.disconnect(callback)](#UbiMqtt+disconnect)
     * [.forceDisconnect(callback)](#UbiMqtt+forceDisconnect)
@@ -96,13 +96,15 @@ Api documentation
 
 <a name="new_UbiMqtt_new"></a>
 
-### new UbiMqtt(serverAddress)
+### new UbiMqtt(serverAddress, [options])
 Class for signed Mqtt communications at Ubikampus
 
 
 | Param | Type | Description |
 | --- | --- | --- |
 | serverAddress | <code>string</code> | the Mqtt server to cennect to |
+| [options] | <code>object</code> |  |
+| [options.silent] | <code>boolean</code> | do not print logs |
 
 <a name="UbiMqtt+connect"></a>
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Api documentation
     * [new UbiMqtt(serverAddress)](#new_UbiMqtt_new)
     * [.connect(callback)](#UbiMqtt+connect)
     * [.disconnect(callback)](#UbiMqtt+disconnect)
+    * [.forceDisconnect(callback)](#UbiMqtt+forceDisconnect)
     * [.publish(topic, message, opts, callback)](#UbiMqtt+publish)
     * [.publishSigned(topic, message, opts, privateKey, callback)](#UbiMqtt+publishSigned)
     * [.subscribe(topic, obj, listener, callback)](#UbiMqtt+subscribe)
@@ -124,6 +125,18 @@ Disconnects from the Mqtt server
 | Param | Type | Description |
 | --- | --- | --- |
 | callback | <code>function</code> | the callback to call upon successful disconnection or error |
+
+<a name="UbiMqtt+forceDisconnect"></a>
+
+### ubiMqtt.forceDisconnect(callback)
+Immediately disconnect without waiting for ACKs. If called before bus
+connection is established, connection is canceled.
+
+**Kind**: instance method of [<code>UbiMqtt</code>](#UbiMqtt)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | called when disconnect succeeds |
 
 <a name="UbiMqtt+publish"></a>
 

--- a/src/ubimqtt.js
+++ b/src/ubimqtt.js
@@ -177,15 +177,14 @@ var handleIncomingMessage = function(topic, message)
 
 self.connect = function(callback)
 	{
-	let tempClient = mqtt.connect(serverAddress);
-
-	tempClient.on("connect", function()
+	client = mqtt.connect(serverAddress);
+	client.on("connect", function()
 		{
-		client = tempClient;
-  	callback(null);
-    });
+		// client = tempClient;
+		callback(null);
+		});
 
-	tempClient.on("message", function (topic, message)
+	client.on("message", function (topic, message)
 		{
 		handleIncomingMessage(topic, message.toString());
 		});
@@ -224,6 +223,19 @@ self.disconnect = function(callback)
 		callback("Error: trying to disconnect non-connected client");
 		}
 	};
+
+/**
+ * Immediately disconnect without waiting for ACKs. If called before bus
+ * connection is established, connection is canceled.
+ *
+ * @function forceDisconnect
+ * @memberOf UbiMqtt#
+ * @param {function} callback called when disconnect succeeds
+ */
+self.forceDisconnect = function(callback)
+	{
+	client.end(true, callback);
+	}
 
 /**
 * Publishes a message on the connected Mqtt server


### PR DESCRIPTION
Currently ubimqtt doesn't provide method for forceful disconnection from the bus, so that disconnecting from the bus will take some time before the connection is finally disposed. This is problematic in situations where previous connection is still alive when trying to reconnect into the bus. The solution is to add new `forceDisconnect` method which allows immediate disconnect.

Additionally add "silent" mode which disables console output from the library.